### PR TITLE
Prevent error when trying to close a not active menu

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -113,7 +113,7 @@ function FeatherMenu:RegisterMenu(menuID, config)
 
     -- close the menu
     function menuClass:Close(options)
-        if FeatherMenu.activeMenu.menuID == menuID then
+        if FeatherMenu.activeMenu and FeatherMenu.activeMenu.menuID == menuID then
             local event = {
                 action = 'closemenu',
                 menuid = menuID


### PR DESCRIPTION
When you try to close a menu that is not open, the script execution will stop 'cause there's not a nil check for the propriety `activeMenu`.
![image](https://github.com/FeatherFramework/feather-menu/assets/15342592/cbfa8245-cd4d-499a-8dc1-b867861b51c2)

How to reproduce:
- Register a menu;
- Call to close it with `menu:Close()`;
- See error on client console.